### PR TITLE
Added github repo to metadata

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -13,6 +13,13 @@ use lib "./lib";
 use Getopt::Long;
 my $version = $Getopt::Long::VERSION_STRING || $Getopt::Long::VERSION;
 
+my $mm_version = $ExtUtils::MakeMaker::VERSION;
+if ($mm_version =~ /_/) {
+    # developer release
+    $mm_version = eval $mm_version;
+    die $@ if $@;
+}
+
 sub MY::postamble {
     my $ret = "";
     my $mandir = $Config{installman3dir};
@@ -94,5 +101,20 @@ WriteMakefile(
 	dist      => { COMPRESS => 'gzip', SUFFIX => 'gz',
 		     },
 	PREREQ_PM => { "Pod::Usage" => 1.14 },
+
+        ($mm_version <= 6.45) ? () : (
+            META_MERGE => {
+                'meta-spec' => { version => 2 },
+                resources => {
+                    repository => {
+                        type => 'git',
+                        web  => 'https://github.com/sciurius/perl-Getopt-Long',
+                        url  => 'https://github.com/sciurius/perl-Getopt-Long.git',
+                    },
+                },
+            },
+        ),
+  
+
  );
 


### PR DESCRIPTION
Hi Johan,

This pull request modifies `Makefile.PL` so that the github repo will be put into the distribution metadata. The repo would then appear in the left sidebar of MetaCPAN, and other tools and systems would pick it up.

Talking of distribution metadata, I noticed that the release on CPAN doesn't have a `META.yml` or `META.json`. It would be handy if the next release had both of these (as `make dist` with recent versions of `ExtUtils::MakeMaker` will do), as that makes the distribution easier to process automatically.

Wasn't sure if you'd want me to update `CHANGES` as well? Happy to update the commit if so.

While I'm here, thank you for your long-term maintenance of this key module.

Cheers,
Neil
