### PR TITLE
Fix regtest portability (MSWindows/*nix and dmake/make)

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -22,6 +22,14 @@ if ($mm_version =~ /_/) {
 
 sub MY::postamble {
     my $ret = "";
+
+    # regtest
+    $ret .= <<EOD;
+regtest .SILENT : all
+	cd regtest && \$(MAKE) \$(PASTHRU) tests
+
+EOD
+
     my $mandir = $Config{installman3dir};
     my $obsolete = "$mandir/Getopt::GetoptLong.3";
     if ( -e $obsolete ) {
@@ -114,7 +122,7 @@ WriteMakefile(
                 },
             },
         ),
-  
+
 
  );
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -26,7 +26,7 @@ sub MY::postamble {
     # regtest
     $ret .= <<EOD;
 regtest .SILENT : all
-	cd regtest && \$(MAKE) \$(PASTHRU) tests
+	cd regtest && \$(MAKE) \$(PASTHRU) test
 
 EOD
 

--- a/regtest/Makefile
+++ b/regtest/Makefile
@@ -9,16 +9,36 @@
 PERL	= perl -w -Mblib
 OPT	= --verbose test.data
 
-all:	test1 aux
+#### OS dependent section (dmake/make compatible)
 
-test1:
+ifeq ($(OS),Windows_NT)
+    OS_detected := MSWindows
+else
+    OS_detected := $(shell uname -s)
+endif
+
+ifeq ($(OS_detected),MSWindows)
+	DOLLAR := $$
+else
+	DOLLAR := \$$
+endif
+
+####
+
+all:	test test_aux
+
+test:
 	$(PERL) -w driver1.pl $(OPT)
+
+test_aux:
+	$(PERL) -E "use English; @files = glob(q/aux*.pl/); for (@files) { print qx[ $(DOLLAR)EXECUTABLE_NAME $(DOLLAR)_ || echo 'FAILED: $(DOLLAR)_'] }"
+	perl -T -Mlib=../blib/lib taint01.pl -opt1 value1 -opt2=value2 || echo 'FAILED: taint01.pl'
+
+####
 
 kit:
 	@echo "use 'perl Makefile.PL; make dist'"
 
-aux:
-	for test in aux*.pl; do \
-	  $(PERL) $$test || echo "FAILED: $$test"; \
-	done
-	perl -T -Mlib=../blib/lib taint01.pl -opt1 value1 -opt2=value2 || echo "FAILED: taint01.pl"
+_info:
+	@echo "OS_detected = '$(OS_detected)'"
+	@echo "DOLLAR = '$(DOLLAR)'"

--- a/regtest/aux003.pl
+++ b/regtest/aux003.pl
@@ -2,7 +2,8 @@
 
 use Getopt::Long 2.3203 qw(:config version);
 
-if ( open FH, "-|" ) {
+if ( pipe_from_fork('FH') ) {
+    # parent
     my $res = <FH>;
     die("res = $res, should be $0\n")
       unless $res eq "$0\n";
@@ -14,7 +15,27 @@ if ( open FH, "-|" ) {
       unless $res eq "$exp\n";
 }
 else {
+    # child
     @ARGV = qw(--version);
     GetOptions("foo");
 }
 
+#### SUBs
+
+# simulate open(FH, "-|") ## from "perldoc perlfork"
+sub pipe_from_fork ## ($FH_NAME): $CHILD_PID
+{
+    use open IO => ':crlf';
+    my $parent = shift;
+    pipe $parent, my $child or die;
+    my $pid = fork();
+    die "fork() failed: $!" unless defined $pid;
+    if ($pid) {
+        close $child;
+    }
+    else {
+        close $parent;
+        open(STDOUT, ">&=" . fileno($child)) or die;
+    }
+    $pid;
+}

--- a/regtest/aux005.pl
+++ b/regtest/aux005.pl
@@ -5,7 +5,8 @@ use Getopt::Long 2.3203 qw(HelpMessage);
 eval { require Pod::Usage };
 warn("Skipped: No Pod::Usage\n"), exit 1 if $@;
 
-if ( open (FH, "-|") ) {
+if ( my $child_pid = pipe_from_fork('FH') ) {
+    # parent
     my $res = <FH>;
     die("res1 = $res, should be Usage:\n")
       unless $res eq "Usage:\n";
@@ -15,12 +16,13 @@ if ( open (FH, "-|") ) {
     $res = <FH>;
     die("res3 = $res, should be \n")
       unless $res eq "\n";
-    $res = close(FH);
+    waitpid( $child_pid, 0 );
     $res = $?;
     die("ret = $res, should be 1<<8\n")
       unless $res == 1<<8;
 }
 else {
+    # child
     HelpMessage(1);
 }
 
@@ -29,3 +31,23 @@ else {
 This is a test message.
 
 =cut
+
+#### SUBs
+
+# simulate open(FH, "-|") ## from "perldoc perlfork"
+sub pipe_from_fork ## ($FH_NAME): $CHILD_PID
+{
+    use open IO => ':crlf';
+    my $parent = shift;
+    pipe $parent, my $child or die;
+    my $pid = fork();
+    die "fork() failed: $!" unless defined $pid;
+    if ($pid) {
+        close $child;
+    }
+    else {
+        close $parent;
+        open(STDOUT, ">&=" . fileno($child)) or die;
+    }
+    $pid;
+}


### PR DESCRIPTION
This PR makes regtest more portable so that the tests can be more easily run on MSWindows machines.

I took a few liberties with the reorganization of the `Makefile`. If you'd like something  a bit different, I'm happy to make the changes and update the PR.
###### Notes
- regtest/Makefile was reorganized and made portable for use with MSWindows/*nix and dmake/make
  - 'aux' was changed to 'test_aux' because a gnu make `make aux` command always saw 'aux' as "up to date" (a bug in gnu make on MSWindows?)
  - target 'aux' (now 'test_aux') modified to use perl as an iterator over the aux*.pl tests (replacing shell-specific code)
  - target 'test1' renamed to 'test' for uniformity
- aux tests using `open( FH, "-|" )` modified to use a more portable implementation
  - implementation slightly modified from "perldoc perlfork" for more portable IO
- 'regtest' target added to the the distribution `Makefile.PL` to ease testing via the usual perl make/dmake process (eg, *nix: `perl Makefile.PL && make test regtest` or MSWindows: `perl Makefile.PL && dmake test regtest`)
