### PR TITLE
provide a default value for optional arguments

### DIFF
--- a/lib/Getopt/Long.pm
+++ b/lib/Getopt/Long.pm
@@ -1122,8 +1122,13 @@ sub FindOption ($$$$$) {
 	    # We do, since not doing so breaks existing scripts.
 	    $optargtype = 3;
 	}
-	return (1, $opt, $ctl, $ctl->[CTL_DEFAULT])
-	  if (($optargtype == 0) && !$mand);
+	if(($optargtype == 0) && !$mand) {
+	    my $val
+	      = defined($ctl->[CTL_DEFAULT]) ? $ctl->[CTL_DEFAULT]
+	      : $type eq 's'                 ? ''
+	      :                                0;
+	    return (1, $opt, $ctl, $val);
+	}
 	return (1, $opt, $ctl, $type eq 's' ? '' : 0)
 	  if $optargtype == 1;  # --foo=  -> return nothing
     }

--- a/regtest/test.data
+++ b/regtest/test.data
@@ -2427,3 +2427,9 @@ A: -a avalue -b extra1 extra2
    @ARGV extra1 extra2
    $v1 avalue
    $v2 1
+
+T: PR#7: Provide a default value for optional arguments (gnu_compat)
+P: foo:s \\&ok
+O: gnu_compat
+A: --foo
+   $v1 ''


### PR DESCRIPTION
When using gnu_compat, FindOption would return undef as the value for
the options with optional arguments if none was provided.  Subsequent
processing in GetOptionsFromArray is skipped entirely for undef values,
causing the option to be silently discarded.  The following code snippet
demonstrates the issue:

 use Getopt::Long qw(GetOptionsFromArray :config gnu_compat);
 GetOptionsFromArray( ['--foo'], 'foo:s' => sub { print("success") } );