### PR TITLE
Fix warnings when getting options after calling Getopt::Long->VERSION

### DIFF
--- a/lib/Getopt/Long.pm
+++ b/lib/Getopt/Long.pm
@@ -1547,7 +1547,7 @@ sub setup_pa_args($@) {
 
 # Sneak way to know what version the user requested.
 sub VERSION {
-    $requested_version = $_[1];
+    $requested_version = $_[1] if @_ > 1;
     shift->SUPER::VERSION(@_);
 }
 


### PR DESCRIPTION
The UNIVERSAL::VERSION method is defined to return the $VERSION (after being run through version.pm) when no arguments are given. The little $requested_version hack here shouldn't care about such calls.

```
$ perl -E'use strict; use warnings; use Getopt::Long; say Getopt::Long->VERSION; GetOptions(\my %foo)'
2.5
Use of uninitialized value $requested_version in numeric ge (>=) at .../Getopt/Long.pm line 483.
Use of uninitialized value $requested_version in numeric ge (>=) at .../Getopt/Long.pm line 490.
```

As a side note, $VERSION should always be defined as a string, to avoid output such as the above not matching what's defined in the module when used as a string. (2.5 vs 2.50)