### PR TITLE
fix a bug caused 'use Getopt::Long 2.4' don't have the documented effect

### DIFF
--- a/lib/Getopt/Long.pm
+++ b/lib/Getopt/Long.pm
@@ -115,7 +115,6 @@ sub import {
     # Hide one level and call super.
     local $Exporter::ExportLevel = 1;
     push(@syms, qw(&GetOptions)) if @syms; # always export GetOptions
-    $requested_version = 0;
     $pkg->SUPER::import(@syms);
     # And configure.
     Configure(@config) if @config;


### PR DESCRIPTION
Getopt::Long->import() was resetting $requested_version to 0 after
Getopt::Long->VERSION() called, so that auto_help/auto_version was
always off if not enabled explicitly even if the version required
greater than 2.3203, which is not consist with the document. So
removed the buggy line.