### PR TITLE
fix repository in META files

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -106,7 +106,11 @@ WriteMakefile(
             META_MERGE => {
                 'meta-spec' => { version => 2 },
                 resources => {
-		  repository => "https://github.com/sciurius/perl-Getopt-Long",
+                    repository => {
+                        type => "git",
+                        url => "https://github.com/sciurius/perl-Getopt-Long.git",
+                        web => "https://github.com/sciurius/perl-Getopt-Long",
+                    },
                 },
             },
         ),


### PR DESCRIPTION
Currently META.json does not contain repository info.
Please look at https://metacpan.org/source/JV/Getopt-Long-2.51/META.json#L40

This PR would fix it.
