### PR TITLE
`Long.pm`: Fix indirect object syntax

### DIFF
--- a/lib/Getopt/Long.pm
+++ b/lib/Getopt/Long.pm
@@ -1520,7 +1520,7 @@ sub VersionMessage(@) {
 sub HelpMessage(@) {
     eval {
 	require Pod::Usage;
-	import Pod::Usage;
+	Pod::Usage->import;
 	1;
     } || die("Cannot provide help: cannot load Pod::Usage\n");
 


### PR DESCRIPTION
Import `Pod::Usage` instead via a regular notation:

```perl
Pod::Usage->import;
```